### PR TITLE
Fix NTFS driver loading on Aarch64

### DIFF
--- a/boot.c
+++ b/boot.c
@@ -33,8 +33,8 @@ STATIC CONST struct {
 } Arch[] = {
 	{ L"x64", L"64-bit x86", L"an x64" },
 	{ L"ia32", L"32-bit x86", L"an x86" },
-	{ L"arm", L"32-bit ARM", L"an ARM" },
 	{ L"aa64", L"64-bit ARM", L"an ARM64" },
+	{ L"arm", L"32-bit ARM", L"an ARM" },
 	{ L"risvc64", L"64-bit RISC-V", L"a RiscV64" },
 	{ L"loongarch64", L"64-bit LoongArch", L"a Loong64" },
 };


### PR DESCRIPTION
The order of elements in the `Arch` array doesn't match the `ArchIndex` values. This results in AArch64 platforms trying to load the `arm` drivers, which causes boot failures with an "Unsupported" error message.

Swap the order of elements to match the `ArchIndex` values.