### PR TITLE
Query highest GOP Resolution, and set it before handing off to window…

### DIFF
--- a/boot.c
+++ b/boot.c
@@ -194,6 +194,54 @@ STATIC EFI_STATUS UnloadDriver(
 }
 
 /*
+ * Switch GOP Console res to the highest available mode, if possible.
+ * When chaining windows for example, inherit a larger resolution for the setup screen.
+ * This is a workaround for the fact that Windows setup does not switch to the highest
+ * available resolution on its own, instead, it will use the resolution of the UEFI GOP console.
+ * This is sometimes 800x600 or 1024x768, which is not ideal for modern displays.
+ */
+STATIC VOID SetHighestGopResolution(VOID)
+{
+	EFI_STATUS Status;
+	EFI_GRAPHICS_OUTPUT_PROTOCOL* Gop = NULL;
+	EFI_GRAPHICS_OUTPUT_MODE_INFORMATION* Info;
+	UINTN SizeOfInfo, Index;
+	UINT32 BestMode = 0;
+	UINT64 BestArea = 0;
+
+	Status = gBS->LocateProtocol(&gEfiGraphicsOutputProtocolGuid, NULL, (VOID**)&Gop);
+	if (EFI_ERROR(Status) || (Gop == NULL)) {
+		PrintWarning(L"Could not locate GOP - display resolution will not be changed");
+		return;
+	}
+
+	for (Index = 0; Index < Gop->Mode->MaxMode; Index++) {
+		Status = Gop->QueryMode(Gop, (UINT32)Index, &SizeOfInfo, &Info);
+		if (EFI_ERROR(Status)) {
+			continue;
+		}
+		if ((UINT64)Info->HorizontalResolution * Info->VerticalResolution > BestArea) {
+			BestArea = (UINT64)Info->HorizontalResolution * Info->VerticalResolution;
+			BestMode = (UINT32)Index;
+		}
+	}
+
+	if (BestArea == 0) {
+		PrintWarning(L"No valid GOP mode found - display resolution will not be changed");
+		return;
+	}
+
+	if (Gop->Mode->Mode != BestMode) {
+		PrintInfo(L"Switching GOP console to highest available resolution: %d (%dx%d)", BestMode,
+			Info->HorizontalResolution, Info->VerticalResolution);
+		Status = Gop->SetMode(Gop, BestMode);
+		if (EFI_ERROR(Status)) {
+			PrintWarning(L"Could not set GOP mode %d: %r", BestMode, Status);
+		}
+	}
+}
+
+/*
  * Display a centered application banner
  */
 STATIC VOID DisplayBanner(VOID)
@@ -513,6 +561,11 @@ EFI_STATUS EFIAPI efi_main(EFI_HANDLE BaseImageHandle, EFI_SYSTEM_TABLE *SystemT
 		PrintErrorStatus(L"  Could not locate '%s'", &LoaderPath[1]);
 		goto out;
 	}
+
+	// Bump the console to its highest GOP res before handing off,
+	// so that windows boot manager / Setup starts at a large resolution
+	// instead of whatever the firmware defaulted to (often 800x600 or 1024x768)
+	SetHighestGopResolution();
 
 	// At this stage, our DevicePath is the partition we are after
 	PrintInfo(L"Launching '%s'...", &LoaderPath[1]);

--- a/boot.h
+++ b/boot.h
@@ -47,6 +47,7 @@
 #include <Protocol/DevicePathToText.h>
 #include <Protocol/DiskIo.h>
 #include <Protocol/DiskIo2.h>
+#include <Protocol/GraphicsOutput.h>
 #include <Protocol/LoadedImage.h>
 
 #include <Guid/FileInfo.h>

--- a/uefi-ntfs.inf
+++ b/uefi-ntfs.inf
@@ -51,6 +51,7 @@
   gEfiDevicePathToTextProtocolGuid
   gEfiDiskIoProtocolGuid
   gEfiDiskIo2ProtocolGuid
+  gEfiGraphicsOutputProtocolGuid
   gEfiLoadedImageProtocolGuid 
   gEfiSimpleFileSystemProtocolGuid
 


### PR DESCRIPTION
…s bootloader, so that the setup runs at better resolutions than 800x600/1024x768 where buttons may be off screen

I have seen on numerous systems that the windows setup on most windows versions (Consumer and Server) will have buttons either cut of partially or entirely, relying on ALT combos to navigate.

In the recent windows 11 iso's, you may be able to see the "Previous Version of Setup" after pressing ALT+N 2 times, this will give a more accessible screen, but some automations don't function with this setup screen.

The fixes applied in this PR query the UEFI GOP Driver for the highest possible resolution, then set it before handing off to the windows setup screen, allowing setup to inherit this higher resolution.

I have tested on systems where this issue has and hasn't been present, all with success.

Looking at the code, this hopefully will not cause any issues with any other systems/OSs